### PR TITLE
fix: replace import with require

### DIFF
--- a/packages/core/dev/test/src/runtime.ts
+++ b/packages/core/dev/test/src/runtime.ts
@@ -28,7 +28,7 @@ if ((globalThis as any).Deno) {
   runtime = "bun";
 } else if ((globalThis as any).process?.versions?.node) {
   runtime = "node";
-  node = import("node:test");
+  node = require("node:test");
 }
 
 export { runtime };


### PR DESCRIPTION
The latest pr fixed an error with Bun, but because i did use of `import` instead of `require`, the node testings did break on latest node versions.

Replace `import` with `require` will fix the issue, tested on node 22 and 23.

Bug:
![image](https://github.com/user-attachments/assets/2e229e0f-8340-4b84-8183-81847375e0c9)

With fix:
![image](https://github.com/user-attachments/assets/6226852d-54e3-4a73-88ae-e140889041ef)

Deno and Bun working without problem:
![image](https://github.com/user-attachments/assets/5684003d-1fa7-47d8-9841-641b71152e28)

Sorry!